### PR TITLE
Replace .remove() by .nativeDelete() for prevent "You need to pass en…

### DIFF
--- a/src/user/test/user.service.spec.ts
+++ b/src/user/test/user.service.spec.ts
@@ -1,5 +1,4 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import crypto from 'crypto';
 import { UserService } from '../user.service';
 import { UserRepository } from '../user.repository';
 import { CreateUserDto } from '../dto';
@@ -27,7 +26,7 @@ describe('UsersService', () => {
       });
     }),
     count: jest.fn().mockImplementation(() => 0),
-    remove: jest.fn().mockImplementation((email: string) => {
+    nativeDelete: jest.fn().mockImplementation(() => {
       return 1;
     }),
     findOneOrFail: jest.fn().mockImplementation((email: string) => {
@@ -82,7 +81,7 @@ describe('UsersService', () => {
     });
   });
   it('should delete user', async () => {
-    expect(await service.delete('test@test.com')).toBe(1);
+    expect(await service.delete('test@test.com')).toBe(undefined);
   });
   it('should create user', async () => {
     expect(

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -64,7 +64,12 @@ export class UserService {
   }
 
   async delete(email: string) {
-    return this.userRepository.remove({ email });
+    const deleted = this.userRepository.nativeDelete({ email });
+
+    if (!deleted) {
+      const errors = { User: ' not found' };
+      throw new HttpException({ errors }, HttpStatus.NOT_FOUND);
+    }
   }
 
   async findById(id: number): Promise<IUserRO> {
@@ -72,7 +77,7 @@ export class UserService {
 
     if (!user) {
       const errors = { User: ' not found' };
-      throw new HttpException({ errors }, 401);
+      throw new HttpException({ errors }, HttpStatus.NOT_FOUND);
     }
 
     return this.buildUserRO(user);


### PR DESCRIPTION
Remove error message "Error: You need to pass entity instance or reference to 'em.remove()'. To remove entities by condition, use 'em.nativeDelete()'." when try to call [DELETE] /api/users/<email>