### PR TITLE
Fixed exception handling in login endpoint

### DIFF
--- a/src/user/test/user.service.spec.ts
+++ b/src/user/test/user.service.spec.ts
@@ -24,6 +24,7 @@ describe('UsersService', () => {
     findOneOrFail: jest.fn().mockImplementation((options) => ({
       id: Date.now(),
       email: 'test@test.com' || options.email,
+      password: 'test' || options.password,
       bio: 'test',
       username: 'test',
       image: 'test.jpg',
@@ -62,6 +63,7 @@ describe('UsersService', () => {
     expect(user).toEqual({
       id: expect.any(Number),
       email: 'test@test.com',
+      password: 'test',
       username: 'test',
       bio: 'test',
       image: 'test.jpg',

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -43,7 +43,7 @@ export class UserController {
   async login(@Body('user') loginUserDto: LoginUserDto): Promise<IUserRO> {
     const foundUser = await this.userService.findOne(loginUserDto);
 
-    const errors = { User: ' not found' };
+    const errors = { message: 'User not found' };
     if (!foundUser) {
       throw new HttpException({ errors }, 401);
     }

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -20,13 +20,13 @@ export class UserService {
     return this.userRepository.findAll();
   }
 
-  async findOne(loginUserDto: LoginUserDto): Promise<User> {
+  async findOne(loginUserDto: LoginUserDto): Promise<User|null> {
     const findOneOptions = {
       email: loginUserDto.email,
       password: crypto.createHmac('sha256', loginUserDto.password).digest('hex'),
     };
 
-    return this.userRepository.findOneOrFail(findOneOptions);
+    return this.userRepository.findOne(findOneOptions);
   }
 
   async create(dto: CreateUserDto): Promise<IUserRO> {

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -20,7 +20,7 @@ export class UserService {
     return this.userRepository.findAll();
   }
 
-  async findOne(loginUserDto: LoginUserDto): Promise<User|null> {
+  async findOne(loginUserDto: LoginUserDto): Promise<User | null> {
     const findOneOptions = {
       email: loginUserDto.email,
       password: crypto.createHmac('sha256', loginUserDto.password).digest('hex'),


### PR DESCRIPTION
We should not return HTTP 500 when user does not exist or password is incorrect